### PR TITLE
log.h: add LOG_LINE_END_AUTO config

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ LOG for C/C++ project, by wrapper and enhance `printf`.
 * Single header file
 * With color on Unix platform
 * Auto print filename and lines
-* Auto line feed by `\n`, can be replaced to `\r\n` by define `LOG_LINE_END_CRLF`
+* Auto line feed `\r`, `\n` or `\r\n` by define `LOG_LINE_END_AUTO`, it depends on platform
 * Release mode(if defined `NDEBUG` or defined `LOG_NDEBUG`) `LOGD` will be ignored
 
 ## Usage

--- a/example.c
+++ b/example.c
@@ -2,6 +2,7 @@
 #include "log.h"
 
 int main() {
+#ifdef LOG_LINE_END_AUTO
     LOG("log");
     LOGT("T", "msg with tag");
     LOGD("debug");
@@ -9,5 +10,14 @@ int main() {
     LOGW("warn");
     LOGE("error");
     LOGF("fatal");
+#else
+    LOG("log\r\n");
+    LOGT("T", "msg with tag\r\n");
+    LOGD("debug\r\n");
+    LOGI("info\r\n");
+    LOGW("warn\r\n");
+    LOGE("error\r\n");
+    LOGF("fatal\r\n");
+#endif
     return 0;
 }

--- a/log.h
+++ b/log.h
@@ -6,7 +6,7 @@
  * LOG_NDEBUG               关闭LOGD的输出
  * LOG_SHOW_VERBOSE         显示LOGV的输出
  * LOG_DISABLE_COLOR        禁用颜色显示
- * LOG_LINE_END_CRLF        默认是\n结尾 添加此宏将以\r\n结尾
+ * LOG_LINE_END_AUTO        添加此宏将根据所用的platform决定以哪种方式结尾
  * LOG_FOR_MCU              MCU项目可配置此宏 更适用于MCU环境
  * LOG_NOT_EXIT_ON_FATAL    FATAL默认退出程序 添加此宏将不退出
  *
@@ -39,10 +39,22 @@
 #include <stdlib.h>
 #endif
 
-#ifdef  LOG_LINE_END_CRLF
+#ifdef LOG_LINE_END_AUTO
+#if defined(_WIN32)
+#define LOG_LINE_END            "\r\n"
+#elif defined(__ANDROID__)
+#define LOG_LINE_END            "\n"
+#elif defined(__linux__) || defined(__unix__)
+#define LOG_LINE_END            "\n"
+#elif defined(__APPLE__)
+#define LOG_LINE_END            "\r"
+#elif defined(LOG_FOR_MCU)
 #define LOG_LINE_END            "\r\n"
 #else
-#define LOG_LINE_END            "\n"
+#define LOG_LINE_END            "\r\n"
+#endif
+#else
+#define LOG_LINE_END            ""
 #endif
 
 #ifdef LOG_NOT_EXIT_ON_FATAL


### PR DESCRIPTION
Some logs do not need to end with automatic newlines, and some key information needs to be printed continuously one by one.

Signed-off-by: Junbo Zheng <3273070@qq.com>